### PR TITLE
FIX: fixed issue with maxiter in the last cell

### DIFF
--- a/ddp_theory_jl.ipynb
+++ b/ddp_theory_jl.ipynb
@@ -956,7 +956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -970,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -981,7 +981,7 @@
        "4"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -999,7 +999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -1012,7 +1012,7 @@
        " -19.9999 "
       ]
      },
-     "execution_count": 26,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1030,7 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -1041,7 +1041,7 @@
        "true"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1059,7 +1059,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -1074,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -1086,20 +1086,7 @@
      "text": [
       "Iterate 0\n",
       " v: [0,0]\n",
-      "Iterate 1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: max_iter exceeded in compute_fixed_point\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Iterate 1\n",
       " sigma:  [3,2]\n",
       " T_sigma(v): [10.0,-1.0]\n",
       " span: 11.0\n",
@@ -1121,14 +1108,6 @@
       "Terminated\n",
       " sigma:  [1,2]\n",
       " v:  [-8.571371007428565,-19.999936376631574]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: max_iter exceeded in compute_fixed_point\n",
-      "WARNING: max_iter exceeded in compute_fixed_point\n"
      ]
     }
    ],
@@ -1158,14 +1137,15 @@
     "        break\n",
     "    end\n",
     "    \n",
-    "    v = compute_fixed_point(T_sigma(ddp, sigma), u,\n",
-    "                            err_tol=0, max_iter=k, verbose=false)\n",
+    "    for j in 1:k\n",
+    "        v = T_sigma(ddp, sigma)(u)\n",
+    "        copy!(u, v)\n",
+    "    end\n",
+    "    copy!(v, u)\n",
+    "    \n",
     "    #The above is equivalent to the following:\n",
-    "    #for j in 1:k\n",
-    "    #    v = T_sigma(ddp, sigma)(u)\n",
-    "    #    copy!(u, v)\n",
-    "    #end\n",
-    "    #copy!(v, u)\n",
+    "    #v = compute_fixed_point(T_sigma(ddp, sigma), u,\n",
+    "    #                        err_tol=0, max_iter=k, verbose=false)\n",
     "    \n",
     "    println(\" T_sigma^k+1(v): $v\")\n",
     "end\n",
@@ -1211,7 +1191,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.4.2",
+   "display_name": "Julia 0.4.3-pre",
    "language": "julia",
    "name": "julia-0.4"
   },
@@ -1219,7 +1199,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.4.2"
+   "version": "0.4.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
No more displaying of the warning about hitting the maximum number of iterations in "compute_fixed_point" (there were a few lines of code in the last cell that were commented out and actually allow avoiding that warning)
